### PR TITLE
Skip IdP setting on profiles with "moderate" prefix

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -2,6 +2,7 @@ package ocp4e2e
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -80,7 +81,7 @@ func TestE2e(t *testing.T) {
 		// empty cleanup function that will be a no-op if the profile setup is skipped.
 		var cleanup func() = func() {}
 		t.Run("Configure test IdP", func(t *testing.T) {
-			if ctx.Profile == "moderate" {
+			if strings.HasPrefix(ctx.Profile, "moderate") {
 				t.Skip("Skipping IdP setup as this doesn't work in this profile.")
 			}
 			cleanup = ctx.ensureIdP(t)


### PR DESCRIPTION
this will be used for the ocp4-moderate-node profile...

Currently, the Gitlab-based IdP doesn't work on FIPS mode. I'll try
switching to Keycloak later.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>