### PR TITLE
Deploy IdP also in moderate profiles

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -2,7 +2,6 @@ package ocp4e2e
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 )
@@ -80,9 +79,6 @@ func TestE2e(t *testing.T) {
 		// empty cleanup function that will be a no-op if the profile setup is skipped.
 		var cleanup func() = func() {}
 		t.Run("Configure test IdP", func(t *testing.T) {
-			if strings.HasPrefix(ctx.Profile, "moderate") {
-				t.Skip("Skipping IdP setup as this doesn't work in this profile.")
-			}
 			cleanup = ctx.ensureIdP(t)
 		})
 


### PR DESCRIPTION
Now that we're using the keycloak IdP, we can test for the IdP setup.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>