### PR TITLE
Sleep before rescan polling

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -558,6 +558,10 @@ func (ctx *e2econtext) doRescan(t *testing.T, s string) {
 			t.Fatalf("failed rescan: %s", err)
 		}
 	}
+
+	// FIXME(jaosorior): We wait just in case it takes too long to propagate.
+	time.Sleep(15 * time.Second)
+
 	var lastErr error
 	err = wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
 		suite := &cmpv1alpha1.ComplianceSuite{}


### PR DESCRIPTION
After annotating the scans for re-scanning. We sleep now 15 seconds to
avoid issues.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>