### PR TITLE
Wait 2 minutes before checking for MachineConfigs

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -71,7 +71,7 @@ func TestE2e(t *testing.T) {
 		}
 		t.Run("Wait for Remediations to apply", func(t *testing.T) {
 			// Lets wait for the MachineConfigs to start applying
-			time.Sleep(30 * time.Second)
+			time.Sleep(2 * time.Minute)
 			ctx.waitForMachinePoolUpdate(t, "master")
 			ctx.waitForMachinePoolUpdate(t, "worker")
 		})


### PR DESCRIPTION
This is mostly useful for the non-MachineConfig related profiles, since
it gives time for the Compliance Operator to apply the remediations

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>