### PR TITLE
set MCP maxUnavailable to 2

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -31,6 +31,7 @@ func TestE2e(t *testing.T) {
 	t.Run("Prereqs setup", func(t *testing.T) {
 		ctx.ensureTestProfileBundle(t)
 		ctx.ensureTestSettings(t)
+		ctx.setPoolRollingPolicy(t)
 	})
 
 	// Remediations


### PR DESCRIPTION
In order to shorten the time for the pool to update, thus to shorten the testing time we are going to set maxUnavailable to 2.