### PR TITLE
Add more complex rule result evaluations

### DIFF
--- a/resultparser/resultparser.go
+++ b/resultparser/resultparser.go
@@ -1,0 +1,96 @@
+package resultparser
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Evaluator interface {
+	Eval(in string) bool
+}
+
+type evalBuilder interface {
+	Eval(in string) bool
+	merge(other evalBuilder) (evalBuilder, error)
+	isleaf() bool
+}
+
+type leaf struct {
+	target string
+}
+
+func (l *leaf) Eval(in string) bool {
+	return strings.EqualFold(l.target, in)
+}
+
+func (l *leaf) isleaf() bool {
+	return true
+}
+
+func (l *leaf) merge(other evalBuilder) (evalBuilder, error) {
+	// nothing to do, this is the first leaf
+	// that's parsed
+	if other == nil {
+		return l, nil
+	}
+	if other.isleaf() {
+		return nil, fmt.Errorf("result eval syntax error: cannot merge leaf and operand")
+	}
+	return other.merge(l)
+}
+
+type orOperand struct {
+	a evalBuilder
+	b evalBuilder
+}
+
+func (oo *orOperand) Eval(in string) bool {
+	return oo.a.Eval(in) || oo.b.Eval(in)
+}
+
+func (oo *orOperand) isleaf() bool {
+	return false
+}
+
+func (oo *orOperand) merge(other evalBuilder) (evalBuilder, error) {
+	// nothing to do, this is the first leaf
+	// that's parsed
+	if other == nil {
+		return nil, fmt.Errorf("result eval or operand syntax error: no operand given")
+	}
+	oo.b = other
+	return oo, nil
+}
+
+type roleResultEvalBase func(string) bool
+type roleResultEval func(string, roleResultEval) bool
+
+func ParseRoleResultEval(rawstring string) (Evaluator, error) {
+	tokens := tokenizeRoleResultEval(rawstring)
+	var currentOperand evalBuilder
+	for _, token := range tokens {
+		switch token {
+		// We'll just handle "or" for now
+		case "or":
+			oo := orOperand{a: currentOperand}
+
+			var err error
+			currentOperand, err = oo.merge(currentOperand)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			l := leaf{target: token}
+			var err error
+			currentOperand, err = l.merge(currentOperand)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return currentOperand, nil
+}
+
+func tokenizeRoleResultEval(rawstring string) []string {
+	return strings.Split(rawstring, " ")
+}

--- a/resultparser/resultparser_test.go
+++ b/resultparser/resultparser_test.go
@@ -1,0 +1,86 @@
+package resultparser
+
+import (
+	"testing"
+)
+
+func TestParseRoleResultEval(t *testing.T) {
+	// Aliases for readability
+	shouldEvalTrue := true
+	shouldErr := true
+	shouldEvalFalse := false
+	noErr := false
+
+	type parserargs struct {
+		rawstring string
+	}
+	tests := []struct {
+		name    string
+		args    parserargs
+		result  string
+		want    bool
+		wantErr bool
+	}{
+		{
+			"Test simple case matches",
+			parserargs{"FOO"},
+			"FOO",
+			shouldEvalTrue,
+			noErr,
+		},
+		{
+			"Test simple case doesn't match",
+			parserargs{"FOO"},
+			"BAR",
+			shouldEvalFalse,
+			noErr,
+		},
+		{
+			"Test two operands fails with error",
+			parserargs{"FOO BAR"},
+			"BAR",
+			shouldEvalFalse,
+			shouldErr,
+		},
+		{
+			"Test simple OR operand matches",
+			parserargs{"FOO or BAR"},
+			"BAR",
+			shouldEvalTrue,
+			noErr,
+		},
+		{
+			"Test multiple OR operand matches",
+			parserargs{"FOO or BAR or BAZ or OZZ or WALRUS"},
+			"WALRUS",
+			shouldEvalTrue,
+			noErr,
+		},
+		{
+			"Test multiple OR operand without matches",
+			parserargs{"FOO or BAR or BAZ or OZZ or WALRUS"},
+			"BEER",
+			shouldEvalFalse,
+			noErr,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRoleResultEval(tt.args.rawstring)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseRoleResultEval() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			} else if (err != nil) && tt.wantErr {
+				return
+			}
+
+			eval := got.Eval(tt.result)
+			t.Logf("Evaluated operand and got = %t", eval)
+			if eval != tt.want {
+				t.Errorf("ParseRoleResultEval() didn't match evaluation. Got = %t, wanted = %t",
+					eval, tt.want)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a small parser to allow us to compare more
complex rules when evaluating results.

e.g. we could now say something like:

```
default_result: PASS or INCONSISTENT
```

Which could be used for rules that are known to fail due to known issues
in OpenShift.

Right now the syntax allows for the following:

```
FOO

FOO or BAR

FOO or BAR or BAZ
```

This doesn't currenlt validate that we're setting correct and specific
results as defined by Compliance Operator. Though this could be easily
added to the parser.

Is this over-engineered? Yes.
Was a parser like this needed? Probably not

But it was sure fun to code :)

The main use-case is a rule that's been failing every once in a while
with INCONSISTENT... It's already reported [1], but it gets no attention
nor do I expect a fix soon.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2001442