### PR TITLE
use result parser on "all roles" as well

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -937,7 +937,11 @@ func matchFoundResultToExpectation(
 ) (bool, error) {
 	// Handle expected result for all roles
 	if resultStr, ok := expectedResult.(string); ok {
-		return strings.EqualFold(string(foundResult.Status), resultStr), nil
+		p, perr := resultparser.ParseRoleResultEval(resultStr)
+		if perr != nil {
+			return false, fmt.Errorf("Error parsing result evaluator: %w", perr)
+		}
+		return p.Eval(string(foundResult.Status)), nil
 	}
 	// Handle role-specific result
 	if resultMap, ok := expectedResult.(map[interface{}]interface{}); ok {


### PR DESCRIPTION
The previous PR only covered cases where it's divided by roles.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>