### PR TITLE
Only clean up IdP if test hasn't failed

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -83,8 +83,18 @@ func TestE2e(t *testing.T) {
 			cleanup = ctx.ensureIDP(t)
 		})
 
+		optionalCleanup := func() {
+			// Only clean up IdP if the test hasn't failed.
+			// This will help us debug IdP issues.
+			if !t.Failed() {
+				t.Log("Cleaning up IdP")
+				cleanup()
+			} else {
+				t.Log("Skipping IdP cleanup")
+			}
+		}
 		// These will get cleaned up at the end of the test
-		defer cleanup()
+		defer optionalCleanup()
 		var scanN int
 
 		for scanN = 2; scanN < 5; scanN++ {


### PR DESCRIPTION
this is meant to help us debug IdP issues. When the test fails (and it
could be because of the IdP, the cleanup doesn't allow us to get
valuable logs.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>