### PR TITLE
Pin keycloak container image to 15.0.1

### DIFF
--- a/vendor/github.com/openshift/cluster-authentication-operator/test/library/keycloakidp.go
+++ b/vendor/github.com/openshift/cluster-authentication-operator/test/library/keycloakidp.go
@@ -37,7 +37,7 @@ func AddKeycloakIDP(
 
 	nsName, keycloakHost, cleanup := deployPod(t, kubeClients, routeClient,
 		"keycloak",
-		"quay.io/keycloak/keycloak:latest",
+		"quay.io/keycloak/keycloak:15.0.1",
 		[]corev1.EnvVar{
 			// configure password for GitLab root user
 			{Name: "KEYCLOAK_USER", Value: "admin"},


### PR DESCRIPTION
`latest` doesn't work with FIPS.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>