### PR TITLE
Add waiting time before applying manual remediation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ all: e2e
 
 .PHONY: e2e
 e2e: ## Run the e2e tests. This requires that the PROFILE and PRODUCT environment variables be set.
+## idp_fix.patch is used to fix route destination cert for keycloak IdP deployment
+	git apply idp_fix.patch
 	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
+	git apply -R idp_fix.patch
 
 .PHONY: help
 help: ## Show this help screen

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -74,6 +74,8 @@ func TestE2e(t *testing.T) {
 		})
 
 		if len(manualRemediations) > 0 {
+			// Wait some time after MachineConfigPool is ready to apply manual remediation
+			time.Sleep(60 * time.Second)
 			t.Run("Apply manual remediations", func(t *testing.T) {
 				ctx.applyManualRemediations(t, manualRemediations)
 			})
@@ -85,24 +87,10 @@ func TestE2e(t *testing.T) {
 			})
 		}
 
-		// empty cleanup function that will be a no-op if the profile setup is skipped.
-		cleanup := func() {}
 		t.Run("Configure test IdP", func(t *testing.T) {
-			cleanup = ctx.ensureIDP(t)
+			ctx.ensureIDP(t)
 		})
 
-		optionalCleanup := func() {
-			// Only clean up IdP if the test hasn't failed.
-			// This will help us debug IdP issues.
-			if !t.Failed() {
-				t.Log("Cleaning up IdP")
-				cleanup()
-			} else {
-				t.Log("Skipping IdP cleanup")
-			}
-		}
-		// These will get cleaned up at the end of the test
-		defer optionalCleanup()
 		var scanN int
 
 		for scanN = 2; scanN < 5; scanN++ {

--- a/idp_fix.patch
+++ b/idp_fix.patch
@@ -1,0 +1,108 @@
+diff --git a/vendor/github.com/openshift/cluster-authentication-operator/test/library/idpdeployment.go b/vendor/github.com/openshift/cluster-authentication-operator/test/library/idpdeployment.go
+index 85e5b45..a945329 100644
+--- a/vendor/github.com/openshift/cluster-authentication-operator/test/library/idpdeployment.go
++++ b/vendor/github.com/openshift/cluster-authentication-operator/test/library/idpdeployment.go
+@@ -77,10 +77,18 @@ func deployPod(
+ 	_, err = clients.CoreV1().Pods(namespace).Create(testContext, pod, metav1.CreateOptions{})
+ 	require.NoError(t, err)
+ 
++	err = WaitForPodCreated(t, clients, "keycloak", namespace)
++	require.NoError(t, err)
++
+ 	_, err = clients.CoreV1().Services(namespace).Create(testContext, svcTemplate(httpPort, httpsPort), metav1.CreateOptions{})
+ 	require.NoError(t, err)
+ 
+-	route, err := routeClient.Routes(namespace).Create(testContext, routeTemplate(useTLS), metav1.CreateOptions{})
++	cmCA, err := clients.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "openshift-service-ca.crt", metav1.GetOptions{})
++	require.NoError(t, err)
++
++	serviceCA := cmCA.Data["service-ca.crt"]
++
++	route, err := routeClient.Routes(namespace).Create(testContext, routeTemplate(useTLS, serviceCA), metav1.CreateOptions{})
+ 	require.NoError(t, err)
+ 
+ 	host, err = WaitForRouteAdmitted(t, routeClient, route.Name, route.Namespace)
+@@ -146,7 +154,7 @@ func svcTemplate(httpPort, httpsPort int32) *corev1.Service {
+ 	}
+ }
+ 
+-func routeTemplate(useTLS bool) *routev1.Route {
++func routeTemplate(useTLS bool, destCA string) *routev1.Route {
+ 	r := &routev1.Route{
+ 		ObjectMeta: metav1.ObjectMeta{
+ 			Name: "test-route",
+@@ -165,14 +173,13 @@ func routeTemplate(useTLS bool) *routev1.Route {
+ 			},
+ 		},
+ 	}
+-
+ 	if useTLS {
+ 		r.Spec.TLS.Termination = routev1.TLSTerminationReencrypt
++		r.Spec.TLS.DestinationCACertificate = destCA
+ 		r.Spec.Port = &routev1.RoutePort{
+ 			TargetPort: intstr.FromString("https"),
+ 		}
+ 	}
+-
+ 	return r
+ }
+ 
+@@ -252,7 +259,7 @@ func addOIDCIDentityProvider(t *testing.T, kubeClients *kubernetes.Clientset, co
+ 		}
+ 	})
+ 
+-	caCMName := idpName + "-ca"
++	caCMName := "openshift-service-ca"
+ 	// configure the default ingress CA as the CA for the IdP in the openshift-config NS
+ 	cleanups = append(cleanups, SyncDefaultIngressCAToConfig(t, kubeClients.CoreV1(), caCMName))
+ 
+@@ -301,6 +308,8 @@ func addIdentityProvider(t *testing.T, kubeClients *kubernetes.Clientset, config
+ 		CleanIDPConfigByName(t, configClient.OAuths(), idp.Name)
+ 	})
+ 
++	configClient.OAuths().Get(context.TODO(), "cluster", metav1.GetOptions{})
++
+ 	if err := WaitForOperatorToPickUpChanges(t, configClient, "authentication"); err != nil {
+ 		return cleanups, err
+ 	}
+diff --git a/vendor/github.com/openshift/cluster-authentication-operator/test/library/waits.go b/vendor/github.com/openshift/cluster-authentication-operator/test/library/waits.go
+index f1d9d6c..b74dc9d 100644
+--- a/vendor/github.com/openshift/cluster-authentication-operator/test/library/waits.go
++++ b/vendor/github.com/openshift/cluster-authentication-operator/test/library/waits.go
+@@ -11,6 +11,7 @@ import (
+ 	"k8s.io/apimachinery/pkg/api/errors"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
++	"k8s.io/client-go/kubernetes"
+ 
+ 	configv1 "github.com/openshift/api/config/v1"
+ 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+@@ -58,7 +59,7 @@ func WaitForClusterOperatorStatus(t *testing.T, client configv1client.ConfigV1In
+ 		conditions := clusterOperator.Status.Conditions
+ 		t.Logf("clusteroperators.config.openshift.io/%v: %v", name, conditionsStatusString(conditions))
+ 		degradedCondition := v1helpers.FindStatusCondition(conditions, configv1.OperatorDegraded)
+-		if degradedCondition.Status == configv1.ConditionTrue {
++		if degradedCondition != nil && degradedCondition.Status == configv1.ConditionTrue {
+ 			t.Logf("clusteroperators.config.openshift.io/%v: degraded is true!: %s:%s", name, degradedCondition.Reason, degradedCondition.Message)
+ 		}
+ 		availableStatusIsMatch, progressingStatusIsMatch, degradedStatusIsMatch, upgradableStatusIsMatch := true, true, true, true
+@@ -117,6 +118,19 @@ func WaitForRouteAdmitted(t *testing.T, client routev1client.RouteV1Interface, n
+ 	return admittedURL, err
+ }
+ 
++func WaitForPodCreated(t *testing.T, client *kubernetes.Clientset, name, ns string) error {
++	t.Logf("waiting for pod %s/%s to be created", ns, name)
++	err := wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
++		_, err := client.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
++		if err != nil {
++			t.Logf("pod.Get(%s/%s) error: %v", ns, name, err)
++			return false, nil
++		}
++		return true, nil
++	})
++	return err
++}
++
+ func WaitForHTTPStatus(t *testing.T, waitDuration time.Duration, client *http.Client, targetURL string, expectedStatus int) error {
+ 	t.Logf("waiting for HEAD at %q to report %d", targetURL, expectedStatus)
+ 


### PR DESCRIPTION
Applying remediation right after Pool is ready might cause some issues, hence let's add some wait before it applies the remediation. 

And also keep the IdP no matter the test's state, so we can have the log.

Change the Idp test-route termination to passthrough, as we need to provide cert for re-encrypt termination