### PR TITLE
Remove IdP Keycloak deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ all: e2e
 
 .PHONY: e2e
 e2e: ## Run the e2e tests. This requires that the PROFILE and PRODUCT environment variables be set.
+## idp_fix.patch is used to fix route destination cert for keycloak IdP deployment
 	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
 
 .PHONY: help

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -74,6 +74,8 @@ func TestE2e(t *testing.T) {
 		})
 
 		if len(manualRemediations) > 0 {
+			// Wait some time after MachineConfigPool is ready to apply manual remediation
+			time.Sleep(60 * time.Second)
 			t.Run("Apply manual remediations", func(t *testing.T) {
 				ctx.applyManualRemediations(t, manualRemediations)
 			})
@@ -85,24 +87,6 @@ func TestE2e(t *testing.T) {
 			})
 		}
 
-		// empty cleanup function that will be a no-op if the profile setup is skipped.
-		cleanup := func() {}
-		t.Run("Configure test IdP", func(t *testing.T) {
-			cleanup = ctx.ensureIDP(t)
-		})
-
-		optionalCleanup := func() {
-			// Only clean up IdP if the test hasn't failed.
-			// This will help us debug IdP issues.
-			if !t.Failed() {
-				t.Log("Cleaning up IdP")
-				cleanup()
-			} else {
-				t.Log("Skipping IdP cleanup")
-			}
-		}
-		// These will get cleaned up at the end of the test
-		defer optionalCleanup()
 		var scanN int
 
 		for scanN = 2; scanN < 5; scanN++ {


### PR DESCRIPTION
This commit works in conjunction with https://github.com/ComplianceAsCode/content/pull/8128, the keycloak deployment keeps falling the CI, we are replacing it with Google IDP.