### PR TITLE
Stash test results into a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.e2e-test-results.out

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: e2e
 .PHONY: e2e
 e2e: ## Run the e2e tests. This requires that the PROFILE and PRODUCT environment variables be set.
 ## idp_fix.patch is used to fix route destination cert for keycloak IdP deployment
-	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
+	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR) | tee .e2e-test-results.out
 
 .PHONY: help
 help: ## Show this help screen


### PR DESCRIPTION
The e2e tests generate a lot of useful debugging information, but it can
overflow tmux buffers. Let's tee the information into a dedicated log
file locally so we can reference it during local runs.

This commit only adds this functionality to the make file target and
also excludes the test log file from the repository. Invoking the tests
manually using `go test` will not generate a log file.