### PR TITLE
Check all Deployment status conditions

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -27,6 +27,9 @@ func TestE2e(t *testing.T) {
 			t.Logf("Skipping operator install as requested")
 		}
 	})
+	if t.Failed() {
+		return
+	}
 
 	t.Run("Prereqs setup", func(t *testing.T) {
 		ctx.ensureTestProfileBundle(t)

--- a/helpers.go
+++ b/helpers.go
@@ -310,7 +310,10 @@ func (ctx *e2econtext) waitForOperatorToBeReady(t *testing.T) {
 		if len(od.Status.Conditions) == 0 {
 			return fmt.Errorf("no conditions for deployment yet")
 		}
-		if od.Status.Conditions[0].Type != appsv1.DeploymentAvailable {
+		for cond := range od.Status.Conditions {
+			if cond.Type == appsv1.DeploymentAvailable {
+				return nil
+			}
 			return fmt.Errorf("the deployment is not ready yet")
 		}
 		return nil


### PR DESCRIPTION
It seems to me that the most recent `Status.Conditions` is appended to the array;
or they are not ordered  at alland we should be checking all of them.

In either case, looking at all the status condition when assessing whether CO is deployed should be enough.

Fixes:
CI runs in witch the `Operator setup` phase fails, but the test continues and seems fine:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-ComplianceAsCode-content-master-4.16-e2e-aws-ocp4-pci-dss-node-weekly/1761526471932776448


References:
Check the example output in [Failed Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#failed-deployment)
