### PR TITLE
Deployment Status Conditions: Fix for loop element

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -310,7 +310,7 @@ func (ctx *e2econtext) waitForOperatorToBeReady(t *testing.T) {
 		if len(od.Status.Conditions) == 0 {
 			return fmt.Errorf("no conditions for deployment yet")
 		}
-		for cond := range od.Status.Conditions {
+		for _, cond := range od.Status.Conditions {
 			if cond.Type == appsv1.DeploymentAvailable {
 				return nil
 			}


### PR DESCRIPTION
We want the object, not the index, :P

Fixes `./helpers.go:314:12: cond.Type undefined (type int has no field or method Type)`
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/ComplianceAsCode_ocp4e2e/32/pull-ci-ComplianceAsCode-ocp4e2e-main-e2e-aws-ocp4-moderate/1762213976051027968/artifacts/e2e-aws-ocp4-moderate/test/build-log.txt
