### PR TITLE
Waiting for Deployment: Check all Status.Conditions before erroring

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -314,9 +314,8 @@ func (ctx *e2econtext) waitForOperatorToBeReady(t *testing.T) {
 			if cond.Type == appsv1.DeploymentAvailable {
 				return nil
 			}
-			return fmt.Errorf("the deployment is not ready yet")
 		}
-		return nil
+		return fmt.Errorf("the deployment is not ready yet")
 	}
 
 	notifyFunc := func(err error, d time.Duration) {


### PR DESCRIPTION
When waiting for the Deployment to be ready we periodically check for its `Status.Conditions`.
But a flawed logic lead us to return `Errorf` on the first Status.Condition, :sweat_smile: 
Let's check all of them before erroring, :smile: 