### PR TITLE
Add basic scan summaries to test logs

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -64,6 +64,7 @@ func TestE2e(t *testing.T) {
 		numberOfFailuresInit = ctx.getFailuresForSuite(t, suite)
 		numberOfCheckResultsInit, manualRemediations = ctx.verifyCheckResultsForSuite(t, suite, false)
 		numberOfInvalidResults = ctx.getInvalidResultsFromSuite(t, suite)
+		ctx.summarizeSuiteFindings(t, suite)
 	})
 
 	// nolint:nestif
@@ -154,4 +155,5 @@ func TestE2e(t *testing.T) {
 				" Got %d Error/None results", numberOfInvalidResults)
 		}
 	})
+	ctx.summarizeSuiteFindings(t, suite)
 }


### PR DESCRIPTION
Since we have the data available to use when we run the tests, we can log a basic summary about how many checks were in specific states. This can be useful when you want to get a quick idea of where a profile is with respect to its pass/fail rate.