### PR TITLE
CMP-2473: Implement flag to bypass remediations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ROOT_DIR?=
 TEST_FLAGS?=-v -timeout 120m
 # Should the test attempt to install the operator?
 INSTALL_OPERATOR?=true
+BYPASS_REMEDIATIONS?=false
 
 GOLANGCI_LINT_VERSION = v1.40.1
 BUILD_DIR := build
@@ -17,7 +18,7 @@ all: e2e
 .PHONY: e2e
 e2e: ## Run the e2e tests. This requires that the PROFILE and PRODUCT environment variables be set.
 ## idp_fix.patch is used to fix route destination cert for keycloak IdP deployment
-	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR) | tee .e2e-test-results.out
+	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR) -bypass-remediations="$(BYPASS_REMEDIATIONS)" | tee .e2e-test-results.out
 
 .PHONY: help
 help: ## Show this help screen

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -67,6 +67,11 @@ func TestE2e(t *testing.T) {
 		ctx.summarizeSuiteFindings(t, suite)
 	})
 
+	if ctx.bypassRemediations {
+		t.Logf("Bypassing remediations and assertions relating to remediations")
+		return
+	}
+
 	// nolint:nestif
 	if numberOfRemediations > 0 || len(manualRemediations) > 0 {
 

--- a/helpers.go
+++ b/helpers.go
@@ -62,10 +62,11 @@ type RuleTest struct {
 }
 
 var (
-	product         string
-	profile         string
-	contentImage    string
-	installOperator bool
+	product            string
+	profile            string
+	contentImage       string
+	installOperator    bool
+	bypassRemediations bool
 )
 
 var (
@@ -80,15 +81,16 @@ type e2econtext struct {
 	ContentImage           string
 	OperatorNamespacedName types.NamespacedName
 	// These are only needed for the test and will only be used in this package
-	rootdir         string
-	profilepath     string
-	product         string
-	resourcespath   string
-	benchmarkRoot   string
-	version         string
-	installOperator bool
-	dynclient       dynclient.Client
-	kubecfg         *rest.Config
+	rootdir            string
+	profilepath        string
+	product            string
+	resourcespath      string
+	benchmarkRoot      string
+	version            string
+	installOperator    bool
+	bypassRemediations bool
+	dynclient          dynclient.Client
+	kubecfg            *rest.Config
 }
 
 func init() {
@@ -97,6 +99,7 @@ func init() {
 	flag.StringVar(&contentImage, "content-image", "", "The path to the image with the content to test")
 	flag.BoolVar(&installOperator, "install-operator", true, "Should the test-code install the operator or not? "+
 		"This is useful if you need to test with your own deployment of the operator")
+	flag.BoolVar(&bypassRemediations, "bypass-remediations", false, "Do not apply remedations and summarize results after the first scan")
 }
 
 func newE2EContext(t *testing.T) *e2econtext {
@@ -128,6 +131,7 @@ func newE2EContext(t *testing.T) *e2econtext {
 		benchmarkRoot:          benchmarkRoot,
 		product:                product,
 		installOperator:        installOperator,
+		bypassRemediations:     bypassRemediations,
 	}
 }
 


### PR DESCRIPTION
In some cases, like running the Compliance Operator on managed offerings, we don't want to assert remediation behavior in the tests because it's not guaranteed users have the ability to remediate.

This commit adds a new flag to short-circuit the test if we don't need to test remediations.