### PR TITLE
Fix typos in platform argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROFILE?=
 # Defines the product that the test aims to test
 # Since we already have test for RHCOS4, this is the default for now.
 PRODUCT?=rhcos4
+PLATFORM?=ocp4
 CONTENT_IMAGE?=quay.io/compliance-operator/compliance-operator-content:latest
 ROOT_DIR?=
 TEST_FLAGS?=-v -timeout 120m
@@ -19,7 +20,7 @@ all: e2e
 .PHONY: e2e
 e2e: ## Run the e2e tests. This requires that the PROFILE and PRODUCT environment variables be set.
 ## idp_fix.patch is used to fix route destination cert for keycloak IdP deployment
-	go test $(TEST_FLAGS) . -platform="$(PLATFROM)" -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR) -bypass-remediations="$(BYPASS_REMEDIATIONS)" | tee .e2e-test-results.out
+	go test $(TEST_FLAGS) . -platform="$(PLATFORM)" -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR) -bypass-remediations="$(BYPASS_REMEDIATIONS)" | tee .e2e-test-results.out
 
 .PHONY: help
 help: ## Show this help screen

--- a/helpers.go
+++ b/helpers.go
@@ -106,7 +106,7 @@ type e2econtext struct {
 func init() {
 	flag.StringVar(&profile, "profile", "", "The profile to check")
 	flag.StringVar(&product, "product", "", "The product this profile is for - e.g. 'rhcos4', 'ocp4'")
-	flag.StringVar(&platform, "platform", "ocp4", "The platform that the tests are running on - e.g. 'ocp', 'rosa'")
+	flag.StringVar(&platform, "platform", "ocp4", "The platform that the tests are running on - e.g. 'ocp4', 'rosa'")
 	flag.StringVar(&contentImage, "content-image", "", "The path to the image with the content to test")
 	flag.BoolVar(&installOperator, "install-operator", true, "Should the test-code install the operator or not? "+
 		"This is useful if you need to test with your own deployment of the operator")


### PR DESCRIPTION
The platform argument was misspelled, causing it to be ignored if you
used it locally with `make e2e`.
