### PR TITLE
Add logging for parsing the profile bundle

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -33,6 +33,7 @@ func TestE2e(t *testing.T) {
 
 	t.Run("Prereqs setup", func(t *testing.T) {
 		ctx.ensureTestProfileBundle(t)
+		ctx.waitForValidTestProfileBundle(t)
 		ctx.ensureTestSettings(t)
 		ctx.setPoolRollingPolicy(t)
 	})


### PR DESCRIPTION
We're hitting issues parsing the profile bundle on ROSA, so let's add
some test logging here to watch the state.
