### PR TITLE
Add more details to remediation timeout

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1228,7 +1228,7 @@ func (ctx *e2econtext) runManualRemediation(t *testing.T, cmdctx goctx.Context, 
 	out, err := cmd.CombinedOutput()
 
 	if errors.Is(cmdctx.Err(), goctx.DeadlineExceeded) {
-		t.Errorf("Command '%s' timed out", rem)
+		t.Errorf("Timed out applying manual remediation script '%s': %s\nError: %s", rem, out, cmdctx.Err())
 		return
 	}
 


### PR DESCRIPTION
Right now, when a remediation times out, the test suite says the command
failed, but only includes a reference to the script that contains the
remediation.

This commit adds the command output and the error so that it's easier to
understand what's going on with the script and why it might be broken.
