### PR TITLE
Increase timeout for applying manual remediations

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -53,7 +53,7 @@ const (
 	apiPollInterval           = 5 * time.Second
 	testProfilebundleName     = "e2e"
 	e2eSettingsName           = "e2e-debug"
-	manualRemediationsTimeout = 30 * time.Minute
+	manualRemediationsTimeout = 60 * time.Minute
 )
 
 // RuleTest is the definition of the structure rule-specific e2e tests should have.


### PR DESCRIPTION
We're seeing timeouts now that we're using `oc adm
wait-for-stable-cluster` as part of the logic to ensure manual
remediations are applied to the cluster.

This commit bumps the context timeout to 1 hour to give the cluster more
time to bounce the cluster operators after the manual remediations are
applied. Otherwise we end up with errors similar to the following:

   Error: context deadline exceeded
