### PR TITLE
Wait for a stable cluster in the suite

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -97,6 +97,10 @@ func TestE2e(t *testing.T) {
 			})
 		}
 
+		if err := ctx.waitForStableCluster(); err != nil {
+			t.Error(err)
+		}
+
 		var scanN int
 
 		for scanN = 2; scanN < 5; scanN++ {

--- a/helpers.go
+++ b/helpers.go
@@ -673,6 +673,14 @@ func (ctx *e2econtext) waitForMachinePoolUpdate(t *testing.T, name string) {
 	}
 }
 
+func (ctx *e2econtext) waitForStableCluster() error {
+	_, err := exec.Command("oc", "adm", "wait-for-stable-cluster", "--minimum-stable-period=2m").Output()
+	if err != nil {
+		return errors.New(fmt.Sprintf("E2E-FAILURE: Cluster failed to stablize after applying remediations: %s", err))
+	}
+	return nil
+}
+
 func (ctx *e2econtext) doRescan(t *testing.T, s string) {
 	scanList := &cmpv1alpha1.ComplianceScanList{}
 	// nolint:errcheck


### PR DESCRIPTION
Some remediations are more invasive than others, and make changes to the
cluster that require time to propagate through the system. Before the
suite starts running subsequent scans, we should wait for it to become
stable so that we know the remediations at least applied properly, or at
the very least didn't make things worse.
