### PR TITLE
Update e2e test suite to wait before kicking a new scan

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -125,10 +125,13 @@ func TestE2e(t *testing.T) {
 				time.Sleep(30 * time.Second)
 				ctx.waitForMachinePoolUpdate(t, "master")
 				ctx.waitForMachinePoolUpdate(t, "worker")
+				// TODO: Vincent056 We need to find a way for usb-guards serviceto be started before we can rescan the cluster
+				// right now we are waiting for 45 seconds, but we need to find a better way to do this
+				time.Sleep(45 * time.Second)
 			})
 		}
 
-		if scanN == 4 {
+		if scanN == 5 {
 			t.Fatalf("Reached maximum number of re-scans. There might be a remediation dependency issue.")
 		}
 


### PR DESCRIPTION
Added a 45 seconds wait after Machineconfig pool finishes updates, this is needed because usb-guard service is not up when the rescan happened and failed the check. Also increased max scan failures retry 