### PR TITLE
CMP-3385: Reduce node remediation time by using smaller node pools

### DIFF
--- a/helpers/setup.go
+++ b/helpers/setup.go
@@ -44,6 +44,10 @@ func Setup(tc *config.TestConfig) error {
 		return err
 	}
 
+	if err := createE2eMachineConfigPool(c); err != nil {
+		return err
+	}
+
 	log.Printf("Setup completed successfully")
 	return nil
 }


### PR DESCRIPTION
Applying node remediations can take a while if we have to reboot the
entire cluster (remediating master and worker nodes). Since we don't
care about uptime in this case, let's add two node pools, one for
e2e-worker and one for e2e-master.

This means we can scan one worker node and one master node while
testing, then remediations only need to be applied to a single node
instead of 3 (by default with the current test setup).

This should hopefully reduce the overall test time since we spend less
time waiting for rolling reboots.
