### PR TITLE
CMP-3385: Reduce time to remediate during tests

### DIFF
--- a/helpers/utilities.go
+++ b/helpers/utilities.go
@@ -368,13 +368,9 @@ func setPoolRollingPolicy(c dynclient.Client) error {
 	for i := range mcfgpools.Items {
 		pool := &mcfgpools.Items[i]
 
-		if strings.Contains(pool.Name, "master") {
-			continue
-		}
-
-		if pool.Spec.MaxUnavailable == nil {
-			log.Printf("Setting pool %s Rolling Policy", pool.Name)
-			maxUnavailable := intstr.FromInt(2)
+		maxUnavailable := intstr.FromString("100%")
+		if pool.Spec.MaxUnavailable != &maxUnavailable {
+			log.Printf("Setting pool %s MaxUnavailable to %s for faster reboots to shorten test times", pool.Name, maxUnavailable.String())
 			pool.Spec.MaxUnavailable = &maxUnavailable
 			if err := c.Update(goctx.TODO(), pool); err != nil {
 				return fmt.Errorf("error updating MachineConfigPool list MaxUnavailable: %w", err)


### PR DESCRIPTION
Increase MaxUnavailable for worker and master MachineConfigPools so that
we don't have to wait so long for the remediations to apply. Some
remediations have dependencies, where one need to be applied before
another, and that results in multiple cluster reboots.

This commit increases the MaxUnavailable policy to 100%, meaning we're
accepting the fact that the master nodes might be down for a while, in
favor of speeding up the tests.
