### PR TITLE
Set ContentDir when TestConfig is created

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,7 @@ func NewTestConfig() *TestConfig {
 		Product:               product,
 		Platform:              platform,
 		ContentImage:          contentImage,
-		ContentDir:            "", // Will be set during setup
+		ContentDir:            contentDir,
 		LogDir:                logDir,
 		InstallOperator:       installOperator,
 		BypassRemediations:    bypassRemediations,


### PR DESCRIPTION
NewTestConfig() always returns a TestConfig with ConentDir empty.

But by the time we create the TestConfig we already know the content directory that should be used, since DefineFlags() runs on TestMain().