### PR TITLE
Use t.Error instead of t.Fatal for assertion checking

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -169,7 +169,7 @@ func TestPlatformCompliance(t *testing.T) {
 		if err = helpers.GenerateMismatchReport(tc, c, mismatchedAssertions, platformBindingName); err != nil {
 			t.Fatalf("Failed to generate test report: %s", err)
 		}
-		t.Fatal("Actual cluster compliance state didn't match expected state")
+		t.Error("Actual cluster compliance state didn't match expected state")
 	}
 
 	err = helpers.GenerateAssertionFileFromResults(tc, c, assertionFileName, initialResults, finalResults)
@@ -282,7 +282,7 @@ func TestNodeCompliance(t *testing.T) {
 		if err = helpers.GenerateMismatchReport(tc, c, mismatchedAssertions, nodeBindingName); err != nil {
 			t.Fatalf("Failed to generate test report: %s", err)
 		}
-		t.Fatal("Actual cluster compliance state didn't match expected state")
+		t.Error("Actual cluster compliance state didn't match expected state")
 	}
 
 	err = helpers.GenerateAssertionFileFromResults(tc, c, assertionFileName, initialResults, finalResults)
@@ -352,7 +352,7 @@ func TestProfile(t *testing.T) {
 		if err = helpers.GenerateMismatchReport(tc, c, mismatchedAssertions, bindingName); err != nil {
 			t.Fatalf("Failed to generate test report: %s", err)
 		}
-		t.Fatal("Actual cluster compliance state didn't match expected state")
+		t.Error("Actual cluster compliance state didn't match expected state")
 	}
 
 	err = helpers.GenerateAssertionFileFromResults(tc, c, assertionFileName, initialResults, nil)
@@ -477,7 +477,7 @@ func TestProfileRemediations(t *testing.T) {
 		if err = helpers.GenerateMismatchReport(tc, c, mismatchedAssertions, bindingName); err != nil {
 			t.Fatalf("Failed to generate test report: %s", err)
 		}
-		t.Fatal("Actual cluster compliance state didn't match expected state")
+		t.Error("Actual cluster compliance state didn't match expected state")
 	}
 
 	err = helpers.GenerateAssertionFileFromResults(tc, c, assertionFileName, initialResults, finalResults)


### PR DESCRIPTION
The tests will fail if there are any discrepancies between the expected
cluster state and the observed state. Using t.Fatalf() or t.Fatal marks
the test as failed, which is what we want, but it also stop execution of
the test. Since we have some helper methods that process the mismatched
results to generate assertion files and reports, we don't want to
completely stop execution so that we can still produce those files.

This commit updates those specific parts of the tests to use Error
instead of Fatal so we perserve the behavior to mark the test as failed,
but continue processing in the test to cleanup and generate reports.
