### PR TITLE
Ignore logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
+logs/
 .*-test-results.out


### PR DESCRIPTION
When running the tests from a local machine, it can be really helpful to
stash the logs in a directory using `-log-dir logs/artifacts/`. But
let's make sure we don't track this in source.
