### PR TITLE
CMP-3836: Add func to check autoremediated results pass

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -146,6 +146,11 @@ func TestPlatformCompliance(t *testing.T) {
 	}
 	afterRemediation = true
 
+	err = helpers.CheckAutomatedRemediationPassed(tc, c, platformBindingName)
+	if err != nil {
+		t.Fatalf("Failed automated remediation check: %s", err)
+	}
+
 	finalResults, err := helpers.CreateResultMap(tc, c, platformBindingName)
 	if err != nil {
 		t.Fatalf("Failed to create result map: %s", err)
@@ -258,6 +263,11 @@ func TestNodeCompliance(t *testing.T) {
 		t.Fatalf("Failed to apply node remediations: %s", err)
 	}
 	afterRemediation = true
+
+	err = helpers.CheckAutomatedRemediationPassed(tc, c, nodeBindingName)
+	if err != nil {
+		t.Fatalf("Failed automated remediation check: %s", err)
+	}
 
 	finalResults, err := helpers.CreateResultMap(tc, c, nodeBindingName)
 	if err != nil {

--- a/helpers/utilities.go
+++ b/helpers/utilities.go
@@ -1762,6 +1762,44 @@ func CreateResultMap(_ *testConfig.TestConfig, c dynclient.Client, suiteName str
 	return resultMap, nil
 }
 
+// CheckAutomatedRemediationPassed verifies that all ComplianceCheckResults with automated remediation
+// are in PASS status. If any automated remediation results are not PASS, it returns an error.
+func CheckAutomatedRemediationPassed(tc *testConfig.TestConfig, c dynclient.Client, suiteName string) error {
+	labelSelectorStr := fmt.Sprintf("%s,%s!=PASS,%s=%s",
+		cmpv1alpha1.ComplianceCheckResultHasRemediation,
+		cmpv1alpha1.ComplianceCheckResultStatusLabel,
+		cmpv1alpha1.SuiteLabel,
+		suiteName,
+	)
+	labelSelector, err := labels.Parse(labelSelectorStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse label selector: %w", err)
+	}
+
+	resultList := &cmpv1alpha1.ComplianceCheckResultList{}
+	opts := &dynclient.ListOptions{
+		LabelSelector: labelSelector,
+		Namespace:     tc.OperatorNamespace.Namespace,
+	}
+	err = c.List(goctx.TODO(), resultList, opts)
+	if err != nil {
+		return fmt.Errorf("failed to get compliance check results for suite %s: %w", suiteName, err)
+	}
+
+	if len(resultList.Items) > 0 {
+		var nonPassResults []string
+		for i := range resultList.Items {
+			result := &resultList.Items[i]
+			nonPassResults = append(nonPassResults, fmt.Sprintf("%s (status: %s)", result.Name, result.Status))
+		}
+		return fmt.Errorf("found %d ComplianceCheckResult(s) with automated remediation that are not in PASS status for suite %s: %v",
+			len(resultList.Items), suiteName, nonPassResults)
+	}
+
+	log.Printf("All ComplianceCheckResults with automated remediation are in PASS status for suite %s", suiteName)
+	return nil
+}
+
 // SaveResultAsYAML saves YAML data about the scan results to a file in the configured log directory.
 func SaveResultAsYAML(tc *testConfig.TestConfig, results map[string]string, filename string) error {
 	p := path.Join(tc.LogDir, filename)


### PR DESCRIPTION
In the downstream profile checks we always check that all the complianeCheckResults that have autoremediations available are PASSing after the last run of rescan. 

Adding this functionality so it gets checked in the upstream as well.

Assisted-by: Cursor