### PR TITLE
CMP-3832: Enhance ocp4e2e suite to cover 76105 logic

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
 	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	cmpv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/ComplianceAsCode/ocp4e2e/config"
 	"github.com/ComplianceAsCode/ocp4e2e/helpers"
 )
@@ -176,6 +178,128 @@ func TestPlatformCompliance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate assertion file: %s", err)
 	}
+}
+
+// TestResourceQuotaExemptRegex ports test case 76105: setting
+// ocp4-var-resource-requests-quota-per-project-exempt-regex to all non–control-plane
+// namespaces (pipe-separated) makes the STIG and moderate quota rules PASS.
+// Intended to run serially with other compliance scans.
+func TestResourceQuotaExemptRegex(t *testing.T) {
+	if tc.TestType != "platform" && tc.TestType != "all" {
+		t.Skipf("Skipping TestResourceQuotaExemptRegex: -test-type is %s (use platform or all)", tc.TestType)
+	}
+	switch runtime.GOARCH {
+	case "arm64", "s390x", "ppc64le":
+		t.Skipf("Skipping TestResourceQuotaExemptRegex on architecture %s", runtime.GOARCH)
+	}
+
+	c, err := helpers.GenerateKubeConfig()
+	if err != nil {
+		t.Fatalf("Failed to generate kube config: %s", err)
+	}
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	ns1 := fmt.Sprintf("ns-76105-a-%s", suffix)
+	ns2 := fmt.Sprintf("ns-76105-b-%s", suffix)
+	tpStig := fmt.Sprintf("tp-76105-stig-%s", suffix)
+	tpMod := fmt.Sprintf("tp-76105-mod-%s", suffix)
+	ssbStig := fmt.Sprintf("ssb-76105-stig-%s", suffix)
+	ssbMod := fmt.Sprintf("ssb-76105-mod-%s", suffix)
+
+	defer func() {
+		if err := helpers.DeleteScanBinding(tc, c, ssbStig); err != nil {
+			t.Logf("cleanup: delete ScanSettingBinding %s: %v", ssbStig, err)
+		} else {
+			if err := helpers.WaitForScanCleanup(tc, c, ssbStig); err != nil {
+				t.Logf("cleanup: WaitForScanCleanup %s: %v", ssbStig, err)
+			}
+		}
+		if err := helpers.DeleteScanBinding(tc, c, ssbMod); err != nil {
+			t.Logf("cleanup: delete ScanSettingBinding %s: %v", ssbMod, err)
+		} else {
+			if err := helpers.WaitForScanCleanup(tc, c, ssbMod); err != nil {
+				t.Logf("cleanup: WaitForScanCleanup %s: %v", ssbMod, err)
+			}
+		}
+		if err := helpers.DeleteTailoredProfile(tc, c, tpStig); err != nil {
+			t.Logf("cleanup: delete TailoredProfile %s: %v", tpStig, err)
+		}
+		if err := helpers.DeleteTailoredProfile(tc, c, tpMod); err != nil {
+			t.Logf("cleanup: delete TailoredProfile %s: %v", tpMod, err)
+		}
+		if err := helpers.DeleteNamespace(c, ns1); err != nil {
+			t.Logf("cleanup: delete namespace %s: %v", ns1, err)
+		}
+		if err := helpers.DeleteNamespace(c, ns2); err != nil {
+			t.Logf("cleanup: delete namespace %s: %v", ns2, err)
+		}
+	}()
+
+	if err := helpers.CreateTestNamespace(c, ns1); err != nil {
+		t.Fatalf("Failed to create test namespace %s: %s", ns1, err)
+	}
+	if err := helpers.CreateTestNamespace(c, ns2); err != nil {
+		t.Fatalf("Failed to create test namespace %s: %s", ns2, err)
+	}
+
+	exemptRegex, err := helpers.NonControlNamespacesExemptRegex(c)
+	if err != nil {
+		t.Fatalf("Failed to build exempt namespace regex: %s", err)
+	}
+	t.Logf("76105 exempt regex length: %d chars", len(exemptRegex))
+
+	const profileStig = "ocp4-stig"
+	const profileModerate = "ocp4-moderate"
+	if err := helpers.ValidateProfile(tc, c, profileStig); err != nil {
+		t.Fatalf("Profile %s not available: %s", profileStig, err)
+	}
+	if err := helpers.ValidateProfile(tc, c, profileModerate); err != nil {
+		t.Fatalf("Profile %s not available: %s", profileModerate, err)
+	}
+
+	if err := helpers.CreateTailoredProfileWithQuotaExemptVariable(tc, c, tpStig, profileStig, exemptRegex); err != nil {
+		t.Fatalf("Failed to create TailoredProfile %s: %s", tpStig, err)
+	}
+	if err := helpers.CreateTailoredProfileWithQuotaExemptVariable(tc, c, tpMod, profileModerate, exemptRegex); err != nil {
+		t.Fatalf("Failed to create TailoredProfile %s: %s", tpMod, err)
+	}
+	if err := helpers.WaitForTailoredProfileReady(tc, c, tpStig); err != nil {
+		t.Fatalf("TailoredProfile %s not ready: %s", tpStig, err)
+	}
+	if err := helpers.WaitForTailoredProfileReady(tc, c, tpMod); err != nil {
+		t.Fatalf("TailoredProfile %s not ready: %s", tpMod, err)
+	}
+
+	if err := helpers.CreateScanBinding(c, tc, ssbStig, tpStig, "TailoredProfile", "default"); err != nil {
+		t.Fatalf("Failed to create ScanSettingBinding %s: %s", ssbStig, err)
+	}
+	if err := helpers.CreateScanBinding(c, tc, ssbMod, tpMod, "TailoredProfile", "default"); err != nil {
+		t.Fatalf("Failed to create ScanSettingBinding %s: %s", ssbMod, err)
+	}
+	if err := helpers.WaitForComplianceSuite(tc, c, ssbStig); err != nil {
+		t.Fatalf("Compliance suite %s did not finish: %s", ssbStig, err)
+	}
+	if err := helpers.WaitForComplianceSuite(tc, c, ssbMod); err != nil {
+		t.Fatalf("Compliance suite %s did not finish: %s", ssbMod, err)
+	}
+
+	ccrStigName := tpStig + "-resource-requests-quota-per-project"
+	ccrModName := tpMod + "-resource-requests-quota"
+	st, err := helpers.GetComplianceCheckResultStatus(tc, c, ccrStigName)
+	if err != nil {
+		t.Fatalf("Failed to get ComplianceCheckResult %s: %s", ccrStigName, err)
+	}
+	if st != cmpv1alpha1.CheckResultPass {
+		t.Fatalf("Expected %s status PASS, got %s", ccrStigName, st)
+	}
+	st, err = helpers.GetComplianceCheckResultStatus(tc, c, ccrModName)
+	if err != nil {
+		t.Fatalf("Failed to get ComplianceCheckResult %s: %s", ccrModName, err)
+	}
+	if st != cmpv1alpha1.CheckResultPass {
+		t.Fatalf("Expected %s status PASS, got %s", ccrModName, st)
+	}
+	t.Logf("TestResourceQuotaExemptRegex: both quota CCRs are PASS")
 }
 
 func TestNodeCompliance(t *testing.T) {

--- a/helpers/utilities.go
+++ b/helpers/utilities.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1733,6 +1735,144 @@ func ValidateProfile(tc *testConfig.TestConfig, c dynclient.Client, profileFQN s
 	}
 	log.Printf("Found profile %s", profileFQN)
 	return nil
+}
+
+// NonControlNamespacesExemptRegex builds a pipe-joined regex string of all namespace names that
+// are not default, kube-*, or openshift*, matching getNonControlNamespacesWithoutStatusChecking.
+// Each name segment is regexp-quoted so the value is safe as a regex alternation.
+func NonControlNamespacesExemptRegex(c dynclient.Client) (string, error) {
+	nsList := &corev1.NamespaceList{}
+	if err := c.List(goctx.TODO(), nsList); err != nil {
+		return "", fmt.Errorf("failed to list namespaces: %w", err)
+	}
+	var names []string
+	for i := range nsList.Items {
+		n := nsList.Items[i].Name
+		if n == "default" {
+			continue
+		}
+		if strings.HasPrefix(n, "kube-") {
+			continue
+		}
+		if strings.HasPrefix(n, "openshift") {
+			continue
+		}
+		names = append(names, regexp.QuoteMeta(n))
+	}
+	sort.Strings(names)
+	return strings.Join(names, "|"), nil
+}
+
+// CreateTestNamespace creates a namespace for tests (e.g. 76105).
+func CreateTestNamespace(c dynclient.Client, name string) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	err := c.Create(goctx.TODO(), ns)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create namespace %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteNamespace deletes a namespace by name; ignores NotFound.
+func DeleteNamespace(c dynclient.Client, name string) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	err := c.Delete(goctx.TODO(), ns)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete namespace %s: %w", name, err)
+	}
+	return nil
+}
+
+// CreateTailoredProfileWithQuotaExemptVariable creates a TailoredProfile that extends a
+// base profile and sets ocp4-var-resource-requests-quota-per-project-exempt-regex.
+func CreateTailoredProfileWithQuotaExemptVariable(
+	tc *testConfig.TestConfig,
+	c dynclient.Client,
+	name, extendsProfile, exemptRegex string,
+) error {
+	tp := &cmpv1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tc.OperatorNamespace.Namespace,
+			Annotations: map[string]string{
+				"compliance.openshift.io/product-type": "Platform",
+			},
+		},
+		Spec: cmpv1alpha1.TailoredProfileSpec{
+			Extends: extendsProfile,
+			Title:   "76105 resource quota exempt variable",
+			Description: "Test ocp4-var-resource-requests-quota-per-project-exempt-regex " +
+				"(case 76105)",
+			SetValues: []cmpv1alpha1.VariableValueSpec{
+				{
+					Name:      "ocp4-var-resource-requests-quota-per-project-exempt-regex",
+					Rationale: "test",
+					Value:     exemptRegex,
+				},
+			},
+		},
+	}
+	err := c.Create(goctx.TODO(), tp)
+	if err != nil {
+		return fmt.Errorf("failed to create TailoredProfile %s: %w", name, err)
+	}
+	return nil
+}
+
+// WaitForTailoredProfileReady waits until the TailoredProfile status.state is READY.
+func WaitForTailoredProfileReady(tc *testConfig.TestConfig, c dynclient.Client, name string) error {
+	key := types.NamespacedName{Name: name, Namespace: tc.OperatorNamespace.Namespace}
+	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(tc.APIPollInterval), 180)
+	return backoff.RetryNotify(func() error {
+		tp := &cmpv1alpha1.TailoredProfile{}
+		if err := c.Get(goctx.TODO(), key, tp); err != nil {
+			return err
+		}
+		if tp.Status.State != cmpv1alpha1.TailoredProfileStateReady {
+			return fmt.Errorf("tailored profile %s state is %s (want READY)", name, tp.Status.State)
+		}
+		return nil
+	}, bo, func(err error, d time.Duration) {
+		log.Printf("waiting for TailoredProfile %s READY after %s: %v", name, d.String(), err)
+	})
+}
+
+// DeleteTailoredProfile deletes a TailoredProfile by name; ignores NotFound.
+func DeleteTailoredProfile(tc *testConfig.TestConfig, c dynclient.Client, name string) error {
+	tp := &cmpv1alpha1.TailoredProfile{}
+	key := types.NamespacedName{Name: name, Namespace: tc.OperatorNamespace.Namespace}
+	err := c.Get(goctx.TODO(), key, tp)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get TailoredProfile %s: %w", name, err)
+	}
+	if err := c.Delete(goctx.TODO(), tp); err != nil {
+		return fmt.Errorf("failed to delete TailoredProfile %s: %w", name, err)
+	}
+	log.Printf("Deleted TailoredProfile %s", name)
+	return nil
+}
+
+// GetComplianceCheckResultStatus returns the status field of a ComplianceCheckResult by metadata name.
+func GetComplianceCheckResultStatus(
+	tc *testConfig.TestConfig,
+	c dynclient.Client,
+	resultName string,
+) (cmpv1alpha1.ComplianceCheckStatus, error) {
+	ccr := &cmpv1alpha1.ComplianceCheckResult{}
+	key := types.NamespacedName{Name: resultName, Namespace: tc.OperatorNamespace.Namespace}
+	if err := c.Get(goctx.TODO(), key, ccr); err != nil {
+		return "", fmt.Errorf("failed to get ComplianceCheckResult %s: %w", resultName, err)
+	}
+	return ccr.Status, nil
 }
 
 // CreateResultMap creates a map of rule names to RuleTest structs from compliance check results.


### PR DESCRIPTION
Up to debate whether to keep this PR or close it directly. It only tests behavior of one variable and two rules, so not sure it this test is worth wasting the resources compared to the value it provides.

Passing when run locally on OCP 4.21: 
```
$ go test -v -timeout 60m   -test-type platform -run TestResourceQuotaExemptRegex -install-operator=false 
2026/03/30 15:50:24 Using default content image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
2026/03/30 15:50:25 ProfileBundle ocp4 is valid
2026/03/30 15:50:25 ProfileBundle rhcos4 is valid
2026/03/30 15:50:26 Setup completed successfully
=== RUN   TestResourceQuotaExemptRegex
    e2e_test.go:249: 76105 exempt regex length: 61 chars
2026/03/30 15:50:28 Found profile ocp4-stig
2026/03/30 15:50:28 Found profile ocp4-moderate
2026/03/30 15:50:29 Created new ScanSettingBinding ssb-76105-stig-1774878626534924671
2026/03/30 15:50:30 Created new ScanSettingBinding ssb-76105-mod-1774878626534924671
2026/03/30 15:50:30 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is LAUNCHING
2026/03/30 15:50:35 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:50:40 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:50:46 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:50:51 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:50:56 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:51:01 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:51:06 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is RUNNING
2026/03/30 15:51:12 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is AGGREGATING
2026/03/30 15:51:17 ComplianceSuite ssb-76105-stig-1774878626534924671 is not DONE: suite ssb-76105-stig-1774878626534924671 scan tp-76105-stig-1774878626534924671 is AGGREGATING
2026/03/30 15:51:22 ComplianceSuite ssb-76105-stig-1774878626534924671 is DONE
2026/03/30 15:51:22 ComplianceSuite ssb-76105-mod-1774878626534924671 is not DONE: suite ssb-76105-mod-1774878626534924671 scan tp-76105-mod-1774878626534924671 is AGGREGATING
2026/03/30 15:51:27 ComplianceSuite ssb-76105-mod-1774878626534924671 is not DONE: suite ssb-76105-mod-1774878626534924671 scan tp-76105-mod-1774878626534924671 is AGGREGATING
2026/03/30 15:51:33 ComplianceSuite ssb-76105-mod-1774878626534924671 is DONE
    e2e_test.go:302: TestResourceQuotaExemptRegex: both quota CCRs are PASS
2026/03/30 15:51:33 Deleted ScanSettingBinding ssb-76105-stig-1774878626534924671
2026/03/30 15:51:33 Waiting for ComplianceSuite and results cleanup for ssb-76105-stig-1774878626534924671
2026/03/30 15:51:34 Still waiting for cleanup after 5s: 18 ComplianceCheckResults still exist for suite ssb-76105-stig-1774878626534924671
2026/03/30 15:51:39 Scan cleanup completed for ssb-76105-stig-1774878626534924671
2026/03/30 15:51:40 Deleted ScanSettingBinding ssb-76105-mod-1774878626534924671
2026/03/30 15:51:40 Waiting for ComplianceSuite and results cleanup for ssb-76105-mod-1774878626534924671
2026/03/30 15:51:40 Still waiting for cleanup after 5s: 28 ComplianceCheckResults still exist for suite ssb-76105-mod-1774878626534924671
2026/03/30 15:51:46 Scan cleanup completed for ssb-76105-mod-1774878626534924671
2026/03/30 15:51:46 Deleted TailoredProfile tp-76105-stig-1774878626534924671
2026/03/30 15:51:46 Deleted TailoredProfile tp-76105-mod-1774878626534924671
--- PASS: TestResourceQuotaExemptRegex (80.96s)
PASS
ok  	github.com/ComplianceAsCode/ocp4e2e	84.013s
```

Assisted-by: Cursor