### PR TITLE
CMP-4478: Fix ProfileBundle reversion on operator restart using Subscription patch

### DIFF
--- a/helpers/setup.go
+++ b/helpers/setup.go
@@ -28,10 +28,8 @@ func Setup(tc *config.TestConfig) error {
 		}
 	}
 
-	if err := ensureTestProfileBundles(c, tc); err != nil {
-		return err
-	}
-
+	// At this point, operator has created ProfileBundles with custom content image
+	// (if custom image was specified, it was added to Subscription before creation)
 	if err := waitForValidTestProfileBundles(c, tc); err != nil {
 		return err
 	}

--- a/helpers/utilities.go
+++ b/helpers/utilities.go
@@ -205,11 +205,72 @@ func ensureSubscriptionExists(c dynclient.Client, tc *testConfig.TestConfig) err
 		s = rosaSubscriptionFileName
 	}
 	p := path.Join(tc.ContentDir, resourcesPath, s)
-	err := createObject(c, p)
+
+	// Read Subscription from YAML
+	obj, err := readObjFromYAMLFilePath(p)
 	if err != nil {
-		return fmt.Errorf("failed to create subscription: %w", err)
+		return fmt.Errorf("failed to read subscription YAML: %w", err)
 	}
+
+	// Add custom content image env var if specified
+	if tc.ContentImage != testConfig.DefaultContentImage {
+		if err := addSubscriptionEnvVar(obj, "RELATED_IMAGE_PROFILE", tc.ContentImage); err != nil {
+			return fmt.Errorf("failed to add RELATED_IMAGE_PROFILE to subscription: %w", err)
+		}
+		log.Printf("Adding RELATED_IMAGE_PROFILE=%s to Subscription", tc.ContentImage)
+	}
+
+	// Create Subscription
+	err = c.Create(goctx.TODO(), obj)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.Printf("Object already exists: %s/%s (%s)", obj.GetNamespace(), obj.GetName(), obj.GetKind())
+		} else {
+			return fmt.Errorf("failed to create subscription: %w", err)
+		}
+	} else {
+		log.Printf("Successfully created object: %s/%s (%s)", obj.GetNamespace(), obj.GetName(), obj.GetKind())
+	}
+
 	return nil
+}
+
+// addSubscriptionEnvVar adds or updates an environment variable in a Subscription's spec.config.env
+func addSubscriptionEnvVar(subscription *unstructured.Unstructured, name, value string) error {
+	// Get existing config.env array, or create empty array if it doesn't exist
+	configEnv, _, err := unstructured.NestedSlice(subscription.Object, "spec", "config", "env")
+	if err != nil {
+		return fmt.Errorf("failed to get config.env: %w", err)
+	}
+
+	// If config.env doesn't exist, initialize it
+	if configEnv == nil {
+		configEnv = []interface{}{}
+	}
+
+	// Check if env var already exists and update it
+	found := false
+	for i := range configEnv {
+		env := configEnv[i].(map[string]interface{})
+		if envName, _, _ := unstructured.NestedString(env, "name"); envName == name {
+			env["value"] = value
+			configEnv[i] = env
+			found = true
+			break
+		}
+	}
+
+	// Add new env var if not found
+	if !found {
+		newEnv := map[string]interface{}{
+			"name":  name,
+			"value": value,
+		}
+		configEnv = append(configEnv, newEnv)
+	}
+
+	// Set the updated config.env array back
+	return unstructured.SetNestedSlice(subscription.Object, configEnv, "spec", "config", "env")
 }
 
 func waitForOperatorToBeReady(c dynclient.Client, tc *testConfig.TestConfig) error {
@@ -239,82 +300,6 @@ func waitForOperatorToBeReady(c dynclient.Client, tc *testConfig.TestConfig) err
 	err := backoff.RetryNotify(retryFunc, bo, notifyFunc)
 	if err != nil {
 		return fmt.Errorf("operator deployment was never created: %w", err)
-	}
-	return nil
-}
-
-func ensureTestProfileBundles(c dynclient.Client, tc *testConfig.TestConfig) error {
-	// Only delete and recreate profile bundles if using a non-default
-	// content image, like ones built in CI or from a development
-	// environment.
-	if tc.ContentImage == testConfig.DefaultContentImage {
-		log.Printf("Using default content image: %s", testConfig.DefaultContentImage)
-		return nil
-	}
-
-	log.Printf("Using content image: %s", tc.ContentImage)
-	defaultBundles := []string{"ocp4", "rhcos4"}
-	for _, bundleName := range defaultBundles {
-		key := types.NamespacedName{
-			Name:      bundleName,
-			Namespace: tc.OperatorNamespace.Namespace,
-		}
-		defaultPB := &cmpv1alpha1.ProfileBundle{}
-		err := c.Get(goctx.TODO(), key, defaultPB)
-		if err == nil {
-			log.Printf("Deleting default profile bundle: %s", bundleName)
-			err = c.Delete(goctx.TODO(), defaultPB)
-			if err != nil {
-				return fmt.Errorf("failed to delete default profile bundle %s: %w", bundleName, err)
-			}
-			log.Printf("Deleted default profile bundle: %s", bundleName)
-		} else if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to check default profile bundle %s: %w", bundleName, err)
-		}
-	}
-
-	// Create profile bundles using the provided ContentImage but reusing
-	// the default profile bundle names.
-	bundles := map[string]string{
-		"ocp4":   "ocp4",
-		"rhcos4": "rhcos4",
-	}
-
-	for bundleName, product := range bundles {
-		key := types.NamespacedName{
-			Name:      bundleName,
-			Namespace: tc.OperatorNamespace.Namespace,
-		}
-		pb := &cmpv1alpha1.ProfileBundle{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      bundleName,
-				Namespace: tc.OperatorNamespace.Namespace,
-			},
-			Spec: cmpv1alpha1.ProfileBundleSpec{
-				ContentImage: tc.ContentImage,
-				ContentFile:  fmt.Sprintf("ssg-%s-ds.xml", product),
-			},
-		}
-
-		bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(tc.APIPollInterval), 180)
-		err := backoff.RetryNotify(func() error {
-			found := &cmpv1alpha1.ProfileBundle{}
-			if err := c.Get(goctx.TODO(), key, found); err != nil {
-				if apierrors.IsNotFound(err) {
-					return c.Create(goctx.TODO(), pb)
-				}
-				return err
-			}
-			// Update the spec in case it differs
-			found.Spec = pb.Spec
-			return c.Update(goctx.TODO(), found)
-		}, bo, func(err error, d time.Duration) {
-			log.Printf("Still waiting for test profile bundle %s to be created after %s: %s", bundleName, d.String(), err)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to ensure test profile bundle %s exists: %w", bundleName, err)
-		}
-		log.Printf("ProfileBundle %s created successfully", bundleName)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

ProfileBundles with custom content images are reverted to default images when the compliance-operator restarts (e.g., node reboots, pod crashes). 

**Root cause:** The operator's `ensureDefaultProfileBundles()` runs at startup and unconditionally patches existing ProfileBundles with the image from the `RELATED_IMAGE_PROFILE` env var, which defaults to the CSV's default image.

**Impact:** Tests using custom content images, from PRs for example, failed intermittently when the operator pod restarted during test execution.

## Solution

Add `RELATED_IMAGE_PROFILE` to `Subscription.spec.config.env` **before creating the Subscription**, so the operator uses the custom content image from startup.

**Why add to Subscription before creation:**
- `Subscription.spec.config.env` is the designed OLM mechanism for env var overrides
- Simpler than create-then-patch approach
- Subscription config persists across OLM reconciliation and operator upgrades
- Subscription env vars take precedence over CSV defaults (documented OLM behavior)
- Solves both initial setup AND restart/reboot cases

## Changes

- Modified `ensureSubscriptionExists()` to add `RELATED_IMAGE_PROFILE` env var to Subscription before creating it (if using custom image)
- Added `addSubscriptionEnvVar()` helper to safely add env vars to `spec.config.env`
- Removed `ensureTestProfileBundles()` (no longer needed - 74 lines removed)
- Simplified `Setup()` flow: install → wait for valid ProfileBundles

## Testing

Run this script to reproduce the original problem and verify the fix:

```bash
#!/bin/bash
# Reproduce the original problem: ProfileBundle with custom image gets reverted on operator restart

# Setup with default image (no custom image specified)
go test -v -timeout 15m . -run='^$' -install-operator=true

# Check ProfileBundle has default image
oc get profilebundle ocp4 -n openshift-compliance -o jsonpath='{.spec.contentImage}'
# Output: ghcr.io/complianceascode/k8scontent:latest

# Manually patch ProfileBundle to custom image (simulating old test approach)
oc patch profilebundle ocp4 -n openshift-compliance --type=merge \
  -p '{"spec":{"contentImage":"quay.io/wsato/ocp4-content:latest"}}'

oc get profilebundle ocp4 -n openshift-compliance -o jsonpath='{.spec.contentImage}'
# Output: quay.io/wsato/ocp4-content:latest

# Restart operator (simulates node reboot)
oc delete pod -l name=compliance-operator -n openshift-compliance
oc wait --for=condition=Ready pod -l name=compliance-operator -n openshift-compliance --timeout=120s

# Check ProfileBundle - OLD APPROACH: reverted to default ❌
oc get profilebundle ocp4 -n openshift-compliance -o jsonpath='{.spec.contentImage}'
# Output: ghcr.io/complianceascode/k8scontent:latest (REVERTED!)

echo ""
echo "=== Now test the FIX ==="
oc delete compliancesuite,compliancescan,profilebundle --all -n openshift-compliance --wait=true && oc delete namespace openshift-compliance && oc delete catalogsource compliance-operator -n openshift-marketplace

# Setup with custom image using NEW approach (adds to Subscription before creation)
go test -v -timeout 15m . -run='^$' -install-operator=true \
  -content-image=quay.io/wsato/ocp4-content:latest

# Check ProfileBundle has custom image
oc get profilebundle ocp4 -n openshift-compliance -o jsonpath='{.spec.contentImage}'
# Output: quay.io/wsato/ocp4-content:latest

# Restart operator (simulates node reboot)
oc delete pod -l name=compliance-operator -n openshift-compliance
oc wait --for=condition=Ready pod -l name=compliance-operator -n openshift-compliance --timeout=120s

# Check ProfileBundle - NEW APPROACH: still has custom image ✅
oc get profilebundle ocp4 -n openshift-compliance -o jsonpath='{.spec.contentImage}'
# Output: quay.io/wsato/ocp4-content:latest (PERSISTS!)
```
