### PR TITLE
CMP-4479: Fix manual remediation script discovery for rules with dashes/underscores

### DIFF
--- a/helpers/utilities.go
+++ b/helpers/utilities.go
@@ -1115,11 +1115,16 @@ func getRuleNameFromResultName(
 
 func convertRuleNameToRegex(ruleName string) string {
 	// Escape any special regex characters in the rule name
-	escaped := regexp.QuoteMeta(ruleName)
-	// Replace literal \- and \_ with a character class that matches both - and _
-	pattern := strings.ReplaceAll(escaped, `\-`, `[-_]`)
-	pattern = strings.ReplaceAll(pattern, `\_`, `[-_]`)
-	return pattern
+	pattern := ""
+    for _, char := range ruleName {
+    	if char == '-' || char == '_' {
+    		pattern += `[-_]`
+    	} else {
+    		// Escape this individual character if it's a regex metacharacter
+    		pattern += regexp.QuoteMeta(string(char))
+    	}
+    }
+    return pattern
 }
 
 func findRulePath(tc *testConfig.TestConfig, rulePattern string) (rulePath string, found bool) {


### PR DESCRIPTION
Problem
  
  Manual remediation scripts were not being discovered and executed for rules
  like:
  - ocp4-cis-idp-is-configured
  - ocp4-cis-audit-log-forwarding-enabled
  
  This caused CI test failures where these rules were expected to PASS after
  remediation but remained FAIL because the remediation scripts never ran.

  Root Cause

  The convertRuleNameToRegex() function had a bug in its logic:

  1. It called regexp.QuoteMeta(ruleName) first to escape special regex
  characters
  2. Then tried to replace \- and \_ with [-_] to match both dashes and
  underscores
  
  The problem: regexp.QuoteMeta() does NOT escape - or _ because they are not
  regex metacharacters outside of character classes. So the string replacements
  looking for \- and \_ found nothing and did nothing.

  Solution
  
  Rewrote convertRuleNameToRegex() to build the pattern character-by-character:
  - For - or _ characters → insert [-_] to match either
  - For other characters → escape individually with QuoteMeta()